### PR TITLE
Replace Java9 (non-LTS) with Java11(with LTS) in Travis job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: bionic
 
 jdk:
 - openjdk8
-- openjdk9
+- openjdk11
 - openjdk14
 
 env:


### PR DESCRIPTION
The CI/CD Travis job was using Java9 which is a non-LTS release. Due to this, the job always downloads Java11 but failing as it is looking for Java9 in JAVA_HOME. As per Java SE roadmap [here](https://www.oracle.com/java/technologies/java-se-support-roadmap.html), Java9 which is a non-LTS release was superseded by Java SE 10 (also non-LTS) and Java SE 10 in turn is immediately superseded by Java SE 11. Java SE 11 however is an LTS release. So, the Travis config is updated to use Java11 instead of Java9 which fixes the issue with CI/CD job.