### PR TITLE
chore(build): Potential fix for code scanning alert no. 1: Depending upon JCenter/Bintray as an artifact repository

### DIFF
--- a/scripts/templates/parent-pom.xml
+++ b/scripts/templates/parent-pom.xml
@@ -95,11 +95,6 @@
             <id>na-artifactory-ibmcloud-sdks</id>
             <url>https://na.artifactory.swg-devops.com:443/artifactory/wcp-ibmcloud-sdks-team-maven-local/</url>
         </repository>
-
-        <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
     </repositories>
 
     <!-- This section is commented out because we use an alternate deploy plugin. 


### PR DESCRIPTION
Potential fix for [https://github.com/IBM/keyprotect-java-client/security/code-scanning/1](https://github.com/IBM/keyprotect-java-client/security/code-scanning/1)

Remove the JCenter repository block from `scripts/templates/parent-pom.xml` under the `<repositories>` section.

Best fix without changing intended functionality:
- Keep the existing internal Artifactory repository entry unchanged.
- Delete only the `<repository>` block that contains:
  - `<id>jcenter</id>`
  - `<url>https://jcenter.bintray.com/</url>`
- Do not add replacement repositories here unless required by project policy, because Maven Central is already the default in Maven and adding extra repositories can alter resolution behavior.

Target region: `scripts/templates/parent-pom.xml`, around lines 99–102 in the provided snippet.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
